### PR TITLE
Enabled api to work with productName as well as productID

### DIFF
--- a/database/database.js
+++ b/database/database.js
@@ -30,7 +30,7 @@ const condition = obj => {
 };
 
 const coloursForProduct = productId => Product
-  .findOne({ productId }, 'colours.colourName colours.colour')
+  .findOne(condition({ productId }), 'colours.colourName colours.colour')
   .then(result => result.colours);
 
 const imageUrlsForColour = (productId, colourName) => Product
@@ -41,7 +41,7 @@ const imageUrlsForColour = (productId, colourName) => Product
   });
 
 const productData = productId => Product
-  .findOne({ productId });
+  .findOne(condition({ productId }));
 
 module.exports = {
   Product,

--- a/database/database.js
+++ b/database/database.js
@@ -19,8 +19,18 @@ const productSchema = new Schema({
 
 const Product = mongoose.model('Product', productSchema);
 
+const condition = obj => {
+  const newObj = {};
+  Object.keys(obj).forEach(key => {
+    if (key === 'productId' && Number.isNaN(parseInt(obj[key], 10))) {
+      newObj.productName = obj[key][0].toUpperCase() + obj[key].slice(1).toLowerCase().replace(/-/g, ' ');
+    } else { newObj[key] = obj[key]; }
+  });
+  return newObj;
+};
+
 const imageUrlsForColour = (productId, colourName) => Product
-  .findOne({ productId, 'colours.colourName': colourName }, 'colours.$')
+  .findOne(condition({ productId, 'colours.colourName': colourName }), 'colours.$')
   .then(result => {
     const { logoUrl, frontUrl, backUrl } = result.colours[0];
     return Promise.resolve({ logoUrl, frontUrl, backUrl });


### PR DESCRIPTION
There's a new function inside database.js that will change the `Model.findOne(...)` `condition` argument to look for `productName` when the incoming `productId` isn't `parseInt`-able.