### PR TITLE
Handle non existent products

### DIFF
--- a/database/database.js
+++ b/database/database.js
@@ -26,8 +26,9 @@ const coloursForProduct = productId => Product
 const imageUrlsForColour = (productId, colourName) => Product
   .findOne({ productId, 'colours.colourName': colourName }, 'colours.$')
   .then(result => {
+    if (result === null) { return null; }
     const { logoUrl, frontUrl, backUrl } = result.colours[0];
-    return Promise.resolve({ logoUrl, frontUrl, backUrl });
+    return { logoUrl, frontUrl, backUrl };
   });
 
 const productData = productId => Product

--- a/database/database.js
+++ b/database/database.js
@@ -21,7 +21,7 @@ const Product = mongoose.model('Product', productSchema);
 
 const coloursForProduct = productId => Product
   .findOne({ productId }, 'colours.colourName colours.colour')
-  .then(result => result.colours);
+  .then(result => (result === null ? null : result.colours));
 
 const imageUrlsForColour = (productId, colourName) => Product
   .findOne({ productId, 'colours.colourName': colourName }, 'colours.$')

--- a/server/index.js
+++ b/server/index.js
@@ -6,9 +6,13 @@ const port = 1729;
 
 app.use(express.static('dist/'));
 
-app.get('/api/productPreview/:productId/colours', (req, res) => {
-  coloursForProduct(req.params.productId)
-    .then(result => res.json(result));
+app.get('/api/productPreview/:productId/colours', (req, res, next) => {
+  const { productId } = req.params;
+  coloursForProduct(productId)
+    .then(result => (result === null
+      ? res.status(404).send(`No such product: ${productId}`)
+      : res.json(result)))
+    .catch(err => next(err));
 });
 
 app.get('/api/productPreview/:productId/:colourName', (req, res) => {

--- a/server/index.js
+++ b/server/index.js
@@ -24,9 +24,13 @@ app.get('/api/productPreview/:productId/:colourName', (req, res, next) => {
     .catch(err => next(err));
 });
 
-app.get('/api/productPreview/:productId', (req, res) => {
-  productData(req.params.productId)
-    .then(results => res.json(results));
+app.get('/api/productPreview/:productId', (req, res, next) => {
+  const { productId } = req.params;
+  productData(productId)
+    .then(result => (result === null
+      ? res.status(404).send(`No such product: ${productId}`)
+      : res.json(result)))
+    .catch(err => next(err));
 });
 
 app.listen(port, () => console.log(`listening on port ${port}`));

--- a/server/index.js
+++ b/server/index.js
@@ -15,10 +15,13 @@ app.get('/api/productPreview/:productId/colours', (req, res, next) => {
     .catch(err => next(err));
 });
 
-app.get('/api/productPreview/:productId/:colourName', (req, res) => {
-  imageUrlsForColour(req.params.productId, req.params.colourName)
-    .then(results => res.json(results))
-    .catch(err => res.json(err));
+app.get('/api/productPreview/:productId/:colourName', (req, res, next) => {
+  const { productId, colourName } = req.params;
+  imageUrlsForColour(productId, colourName)
+    .then(result => (result === null
+      ? res.status(404).send(`No such product/colour: ${productId}/${colourName}`)
+      : res.json(result)))
+    .catch(err => next(err));
 });
 
 app.get('/api/productPreview/:productId', (req, res) => {


### PR DESCRIPTION
Server should now properly handle a non-existent `productId`. Once `api-routes-with-product-name` is merged into `master`, it should work for a non-existent `productName` without any additional work.